### PR TITLE
Resolve build errors and update integration guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,25 @@
-# raspi
+# Raspberry Pi 3B+ platform
 
-Raspberry Pi 3B+ platform
+## Integration steps
 
-In order to compile an application that will run on the Raspberry Pi 3B+, please
-select/deselect the following options in the make menuconfig:
-- Architecture Selection --> Architecture --> select: Arrmv8 compatible (64 bits)
-- Architecture Selection --> Processor Optimization --> select: Generic Armv8 Cortex A53
-- Architecture Selection --> deselect: Workaround for Cortex-A73 erratum
-- Platform Configuration --> select: Raspberry Pi 3B+
-- Library Configuration --> ukboot --> deselect: Show Unikraft banner (this is to minimize boot time)
-- Build Options --> select: Drop unused functions and data
+In order to compile an application that will run on the Raspberry Pi 3B+, please:
+- clone this repository into **unikraft/plat/** using following command
 
-Once built, in a blank SD card formated to FAT32, copy the generated kernel8.img Unikraft image (without changing
-the name of the image file, as otherwise the Raspberry Pi's bootloader will not recongize it), plus the four files
-that are inside the plats/raspi/bootfiles folder (i.e., bootcode.bin, config.txt, fixup.dat, and start.elf).
+```
+cd unkiraft/plat
+git clone --branch spagani-devel git@github.com:unikraft/plat-raspi.git raspi
+```
+- update **unikraft/plat/Makefile.uk** to register the Raspberry Pi platform we just cloned.
+```
+echo '$(eval $(call _import_lib,$(UK_PLAT_BASE)/raspi))' >> Makefile.uk
+```
+- run `make menuconfig` in unikraft directory
+- select/deselect the following options in the make menuconfig:
+	- Architecture Selection --> Architecture --> select: Armv8 compatible (64 bits)
+	- Architecture Selection --> Processor Optimization --> select: Generic Armv8 Cortex A53
+	- Architecture Selection --> deselect: Workaround for Cortex-A73 erratum
+	- Platform Configuration --> select: Raspberry Pi 3B+
+	- Library Configuration --> ukboot --> deselect: Show Unikraft banner (this is to minimize boot time)
+	- Build Options --> select: Drop unused functions and data
+
+Once built, in a blank SD card formated to FAT32, copy the generated kernel8.img Unikraft image (without changing the name of the image file, as otherwise the Raspberry Pi's bootloader will not recongize it), plus the four files that are inside the plat/raspi/bootfiles folder (i.e., bootcode.bin, config.txt, fixup.dat, and start.elf).

--- a/io.c
+++ b/io.c
@@ -39,7 +39,7 @@
  * For our Raspberry Pi platform, the guest virtual address == guest physical address.
  * We may have to reconsider this implementation when condition changes.
  */
-__phys_addr ukplat_virt_to_phys(const volatile void *address)
+__paddr_t ukplat_virt_to_phys(const volatile void *address)
 {
-	return (__phys_addr)address;
+	return (__paddr_t)address;
 }

--- a/memory.c
+++ b/memory.c
@@ -39,7 +39,7 @@ int ukplat_memregion_get(int i, struct ukplat_memregion_desc *m)
 	switch (i) {
 	case 0: /* stack */
 		m->base  = (void *) 0;
-		m->len   = (size_t) __TEXT;
+		m->len   = (__sz) __TEXT;
 		m->flags = (UKPLAT_MEMRF_RESERVED
 			    | UKPLAT_MEMRF_READABLE
 			    | UKPLAT_MEMRF_WRITABLE);
@@ -50,7 +50,7 @@ int ukplat_memregion_get(int i, struct ukplat_memregion_desc *m)
 		break;
 	case 1: /* text */
 		m->base  = (void *) __TEXT;
-		m->len   = (size_t) __ETEXT - (size_t) __TEXT;
+		m->len   = (__sz) __ETEXT - (__sz) __TEXT;
 		m->flags = (UKPLAT_MEMRF_RESERVED
 			    | UKPLAT_MEMRF_READABLE);
 #if CONFIG_UKPLAT_MEMRNAME
@@ -60,7 +60,7 @@ int ukplat_memregion_get(int i, struct ukplat_memregion_desc *m)
 		break;
 	case 2: /* rodata */
 		m->base  = (void *) __RODATA;
-		m->len   = (size_t) __ERODATA - (size_t) __RODATA;
+		m->len   = (__sz) __ERODATA - (__sz) __RODATA;
 		m->flags = (UKPLAT_MEMRF_RESERVED
 			    | UKPLAT_MEMRF_READABLE);
 #if CONFIG_UKPLAT_MEMRNAME
@@ -70,7 +70,7 @@ int ukplat_memregion_get(int i, struct ukplat_memregion_desc *m)
 		break;
 	case 3: /* ctors */
 		m->base  = (void *) __CTORS;
-		m->len   = (size_t) __ECTORS - (size_t) __CTORS;
+		m->len   = (__sz) __ECTORS - (__sz) __CTORS;
 		m->flags = (UKPLAT_MEMRF_RESERVED
 			    | UKPLAT_MEMRF_READABLE);
 #if CONFIG_UKPLAT_MEMRNAME
@@ -80,7 +80,7 @@ int ukplat_memregion_get(int i, struct ukplat_memregion_desc *m)
 		break;
 	case 4: /* data */
 		m->base  = (void *) __DATA;
-		m->len   = (size_t) __EDATA - (size_t) __DATA;
+		m->len   = (__sz) __EDATA - (__sz) __DATA;
 		m->flags = (UKPLAT_MEMRF_RESERVED
 			    | UKPLAT_MEMRF_READABLE
 			    | UKPLAT_MEMRF_WRITABLE);
@@ -91,7 +91,7 @@ int ukplat_memregion_get(int i, struct ukplat_memregion_desc *m)
 		break;
 	case 5: /* bss */
 		m->base  = (void *) __BSS_START;
-		m->len   = (size_t) __END - (size_t) __BSS_START;
+		m->len   = (__sz) __END - (__sz) __BSS_START;
 		m->flags = (UKPLAT_MEMRF_RESERVED
 			    | UKPLAT_MEMRF_READABLE
 			    | UKPLAT_MEMRF_WRITABLE);
@@ -102,7 +102,7 @@ int ukplat_memregion_get(int i, struct ukplat_memregion_desc *m)
 		break;
 	case 6: /* heap */
 		m->base  = (void *) __END;
-		m->len   = (size_t) (MMIO_BASE/2 - 1) - (size_t) __END;
+		m->len   = (__sz) (MMIO_BASE/2 - 1) - (__sz) __END;
 		m->flags = UKPLAT_MEMRF_ALLOCATABLE;
 #if CONFIG_UKPLAT_MEMRNAME
 		m->name  = "heap";


### PR DESCRIPTION
Hi,
As a part  Unikraft Weekly Hackathon, I have removed build errors from plat-raspi(spagani-devel) branch and updated the README.md for improved integration guide. 

Precisely, I have replaced  `__phys_addr` with `__paddr_t` in **io.c**. `__phys_addr` is an obsolete/undefined type after [this commit](https://github.com/unikraft/unikraft/commit/0043e56a7279a581073f62093a511f27c999795f) by @marcrittinghaus. 

Another change I made was replacing `size_t` with `__sz`, size_t was also not defined(or stddef.h was not included.), so I replaced `size_t` with `__sz` in **memory.c**. `__sz` is a type, equivalent to `size_t`. 



Sikkiladho(Mushahid Hussain) 